### PR TITLE
Indent rules

### DIFF
--- a/indent/purescript.vim
+++ b/indent/purescript.vim
@@ -75,7 +75,7 @@ function! GetPurescriptIndent()
 
   if line =~ '^\s*\<where\>'
     let s = match(prevline, '\S')
-    return s + &shiftwidth
+    return s + &l:shiftwidth
   endif
 
   if line =~ '^\s*\<in\>'
@@ -114,8 +114,8 @@ function! GetPurescriptIndent()
   endif
 
   if prevline =~ '^\S'
-    " starting type signature, function body, data & newtype on next line
-    return &shiftwidth
+    " start typing signature, function body, data & newtype on next line
+    return &l:shiftwidth
   endif
 
   if ppline =~ '^\S' && prevline =~ '^\s*$'
@@ -123,7 +123,7 @@ function! GetPurescriptIndent()
   endif
 
   if line =~ '^\s*::'
-    return match(prevline, '\S') + &shiftwidth
+    return match(prevline, '\S') + &l:shiftwidth
   endif
 
   if prevline =~ '^\s*::\s*forall'
@@ -156,9 +156,9 @@ function! GetPurescriptIndent()
 
     let s = match(prevline, '\<:\>')
     if s > 0
-      return s + &shiftwidth
+      return s + &l:shiftwidth
     else
-      return match(prevline, '\S') + &shiftwidth
+      return match(prevline, '\S') + &l:shiftwidth
     endif
   endif
 
@@ -197,12 +197,12 @@ function! GetPurescriptIndent()
 
   let s = match(prevline, '\(\<where\>\|\<do\>\|=\)\s*$')
   if s >= 0 && index(s:GetSynStack(v:lnum - 1, s), 'purescriptString') == -1
-    return match(prevline, '\S') + &shiftwidth
+    return match(prevline, '\S') + &l:shiftwidth
   endif
 
   let s = match(prevline, '[{([]\s*$')
   if s >= 0 && index(s:GetSynStack(v:lnum - 1, s), 'purescriptString') == -1
-    return match(prevline, '\S') + (line !~ '^\s*[})]]' ? 0 : &shiftwidth)
+    return match(prevline, '\S') + (line !~ '^\s*[})]]' ? 0 : &l:shiftwidth)
   endif
 
   let s = match(prevline, '\<where\>\s\+\S\+.*$')
@@ -226,12 +226,12 @@ function! GetPurescriptIndent()
   endif
 
   if prevline =~ '^\s*\<\data\>\s\+\S\+\s*$'
-    return match(prevline, '\<data\>') + &shiftwidth
+    return match(prevline, '\<data\>') + &l:shiftwidth
   endif
 
   let s = match(prevline, '^\s*[}\]]')
   if s >= 0 && index(s:GetSynStack(v:lnum - 1, s), 'purescriptString') == -1
-    return match(prevline, '\S') - &shiftwidth
+    return match(prevline, '\S') - &l:shiftwidth
   endif
 
   return match(prevline, '\S')

--- a/indent/purescript.vim
+++ b/indent/purescript.vim
@@ -81,7 +81,7 @@ function! GetPurescriptIndent()
 
     while s <= 0 && n > 0
       let n = n - 1
-      let s = match(getline(n),'\<let\>')
+      let s = match(getline(n), '\<let\>')
     endwhile
 
     return s + g:purescript_indent_in
@@ -159,6 +159,16 @@ function! GetPurescriptIndent()
   if prevline =~ '[{([][^})\]]\+$'
     echom "return 1"
     return match(prevline, '[{([]')
+  endif
+
+  let s = match(prevline, '\<let\>\s\+\zs\S')
+  if s >= 0
+    return s
+  endif
+
+  let s = match(prevline, '\<let\>\s*$')
+  if s >= 0
+    return s + g:purescript_indent_let
   endif
 
   if prevline =~ '\<let\>\s\+.\+\(\<in\>\)\?\s*$'

--- a/indent/purescript.vim
+++ b/indent/purescript.vim
@@ -113,6 +113,18 @@ function! GetPurescriptIndent()
     return s
   endif
 
+  " indent rules for -> (lambdas and case expressions)
+  let s = match(line, '->')
+  " protect that we are not in a type signature
+  if s >= 0 && prevline !~ '^\s*\(->\|=>\|::\|\.\)'
+    let p = match(prevline, '\\')
+    if p >= 0 && index(s:GetSynStack(v:lnum - 1, p), "purescriptString") == -1
+      return p
+    else
+      return match(prevline, '\S') + &l:shiftwidth
+    endif
+  endif
+
   if prevline =~ '^\S'
     " start typing signature, function body, data & newtype on next line
     return &l:shiftwidth


### PR DESCRIPTION
* indent let declarations
* protect against matching inside strings
* `&l:shiftwidth`
* indent rules for `->`: case and lambda expressions