### PR TITLE
Perform spell-checking only in strings and comments

### DIFF
--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -138,14 +138,14 @@ syn match purescriptTypeAliasStart "^type\s\+\([A-Z]\w*\)" contained
 
 " String
 syn match purescriptChar "'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'"
-syn region purescriptString start=+"+ skip=+\\\\\|\\"+ end=+"+
-syn region purescriptMultilineString start=+"""+ end=+"""+ fold
+syn region purescriptString start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
+syn region purescriptMultilineString start=+"""+ end=+"""+ fold contains=@Spell
 
 " Comment
-syn match purescriptLineComment "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$"
+syn match purescriptLineComment "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$" contains=@Spell
 syn region purescriptBlockComment start="{-" end="-}" fold
-  \ contains=purescriptBlockComment
-syn cluster purescriptComment contains=purescriptLineComment,purescriptBlockComment
+  \ contains=purescriptBlockComment,@Spell
+syn cluster purescriptComment contains=purescriptLineComment,purescriptBlockComment,@Spell
 
 syn sync minlines=50
 


### PR DESCRIPTION
Without adding `contains=@Spell` it seems that vim will spellcheck the entire document. I've added this parameter to comments and strings.

Before:

<img width="339" alt="screen shot 2018-03-08 at 8 07 46 pm" src="https://user-images.githubusercontent.com/34294193/37186711-6c955c06-230c-11e8-85c1-8eed8397e460.png">

After:

<img width="335" alt="vim spellcheck purescript" src="https://user-images.githubusercontent.com/34294193/37186658-329f42be-230c-11e8-9f25-c1b3f464fb3b.png">