### PR TITLE
Add "pipe block" comment style

### DIFF
--- a/ftplugin/purescript.vim
+++ b/ftplugin/purescript.vim
@@ -1,4 +1,4 @@
-setlocal comments=s1fl:{-,mb:\ \ ,ex:-},:--
+setlocal comments=s1fl:{-,mb:\ \ ,ex:-},:--\ \|,:--
 setlocal include=^import
 setlocal includeexpr=printf('%s.purs',substitute(v:fname,'\\.','/','g'))
 


### PR DESCRIPTION
A common style of comment block in PureScript starts each line with `-- |`, for example:

```purescript
-- | This is a very
-- | important comment.
f = id
```

This commit adds that style to the allowed list.