### PR TITLE
Indentation level after type declaration (#51)

### DIFF
--- a/indent/purescript.vim
+++ b/indent/purescript.vim
@@ -101,7 +101,7 @@ function! GetPurescriptIndent()
     return s
   endif
 
-  if prevline =~ '^\S.*::' && line !~ '^\s*\(\.\|->\|→\|=>\|⇒\)' && !~ '^instance'
+  if prevline =~ '^\S.*::' && line !~ '^\s*\(\.\|->\|→\|=>\|⇒\)' && prevline !~ '^instance'
     " f :: String
     "	-> String
     return 0


### PR DESCRIPTION
If we're on the line following a type annotation,
and our line doesn't start with dots or arrows,
and the previous line isn't an instance declaration,
then indentation level is 0.