### PR TITLE
Move commentstring to ftplugin

### DIFF
--- a/ftdetect/purescript.vim
+++ b/ftdetect/purescript.vim
@@ -1,2 +1,1 @@
 au BufNewFile,BufRead *.purs setf purescript
-au FileType purescript let &l:commentstring='{--%s--}'

--- a/ftplugin/purescript.vim
+++ b/ftplugin/purescript.vim
@@ -1,4 +1,5 @@
 setlocal comments=s1fl:{-,mb:\ \ ,ex:-},:--\ \|,:--
+setlocal commentstring=--\ %s
 setlocal include=^import
 setlocal includeexpr=printf('%s.purs',substitute(v:fname,'\\.','/','g'))
 


### PR DESCRIPTION
The standard practice is to put commentstring inside ftplugin, not ftdetect.

I've also changed it to inline comment, as in #59