### PR TITLE
Add option to disable indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Breaking changes (😱!!!):
 
 New features:
   - add vim manual (`:help purescript-vim`) [p73][]
-  - add setting to disable indentation (`let g:purescript_disable_indent = 1`) [pXX][]
+  - add setting to disable indentation (`let g:purescript_disable_indent = 1`) [p75][]
 
 Bugfixes:
   - docs did not reflect the code in using the `g:` prefix for indentation configuration [p73][]
@@ -61,4 +61,4 @@ class RowLacking (entry :: Type)
 
 [p68][https://github.com/purescript-contrib/purescript-vim/pull/70]
 [p73][https://github.com/purescript-contrib/purescript-vim/pull/73]
-[pXX][]
+[p75][https://github.com/purescript-contrib/purescript-vim/pull/75]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes (😱!!!):
 
 New features:
   - add vim manual (`:help purescript-vim`) [p73][]
+  - add setting to disable indentation (`let g:purescript_disable_indent = 1`) [pXX][]
 
 Bugfixes:
   - docs did not reflect the code in using the `g:` prefix for indentation configuration [p73][]
@@ -60,3 +61,4 @@ class RowLacking (entry :: Type)
 
 [p68][https://github.com/purescript-contrib/purescript-vim/pull/70]
 [p73][https://github.com/purescript-contrib/purescript-vim/pull/73]
+[pXX][]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Save and restart (neo)vim and run `:PlugInstall`.
 
 To configure indentation in `purescript-vim` you can use the following variables:
 
+#### g:purescript_disable_indent
+
+Disable indentation altogether.
+
+```vim
+let g:purescript_indent_case = 1
+```
+
 #### g:purescript_indent_case
 
 ```vim

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To configure indentation in `purescript-vim` you can use the following variables
 Disable indentation altogether.
 
 ```vim
-let g:purescript_indent_case = 1
+let g:purescript_disable_indent = 1
 ```
 
 #### g:purescript_indent_case

--- a/doc/purescript-vim.txt
+++ b/doc/purescript-vim.txt
@@ -4,15 +4,17 @@
 |purescript-Installation|    Installation
 |purescript-Manual-Installation-no-plugin-manager|    Manual Installation (no plugin manager)
 |purescript-Pathogen|    Pathogen
-|purescript-plug-vim|    plug-vim
+|purescript-vim-plug|    vim-plug
 |purescript-Configuration|    Configuration
 |purescript-Indentation|    Indentation
+|purescript-g-purescript_disable_indent|    g:purescript_disable_indent
 |purescript-g-purescript_indent_case|    g:purescript_indent_case
 |purescript-g-purescript_indent_let|    g:purescript_indent_let
 |purescript-g-purescript_indent_in|    g:purescript_indent_in
 |purescript-g-purescript_indent_where|    g:purescript_indent_where
 |purescript-g-purescript_indent_do|    g:purescript_indent_do
 |purescript-g-purescript_indent_dot|    g:purescript_indent_dot
+|purescript-Contributing|    Contributing
 
 PURESCRIPT-VIM                *purescript-intro*
 
@@ -49,7 +51,7 @@ If you are using [Pathogen][], clone this repo into your `~/.vim/bundle` directo
 <
 
 
-PLUG-VIM                *purescript-plug-vim*
+VIM-PLUG                *purescript-vim-plug*
 
 If you are using [vim-plug][], add the following line in between your `plug#begin` and `plug#end` calls for your vim config file:
 
@@ -66,6 +68,15 @@ CONFIGURATION                *purescript-Configuration*
 INDENTATION                *purescript-Indentation*
 
 To configure indentation in `purescript-vim` you can use the following variables:
+
+
+G:PURESCRIPT_DISABLE_INDENT                *purescript-g-purescript_disable_indent*
+
+Disable indentation altogether.
+
+>
+    let g:purescript_indent_case = 1
+<
 
 
 G:PURESCRIPT_INDENT_CASE                *purescript-g-purescript_indent_case*
@@ -141,6 +152,19 @@ G:PURESCRIPT_INDENT_DOT                *purescript-g-purescript_indent_dot*
           >. List a
           -> Maybe (List a, a)
 <
+
+
+CONTRIBUTING                *purescript-Contributing*
+
+Contributing checklist:
+
+[ ] Opened an issue before investing a significant amount of work into changes
+
+[ ] Update README.md with any new configuration options and behavior
+
+[ ] Update CHANGELOG.md with the proposed changes
+
+[ ] Run `generate-doc.sh` to re-generate the documentation
 
 
 

--- a/doc/purescript-vim.txt
+++ b/doc/purescript-vim.txt
@@ -75,7 +75,7 @@ G:PURESCRIPT_DISABLE_INDENT                *purescript-g-purescript_disable_inde
 Disable indentation altogether.
 
 >
-    let g:purescript_indent_case = 1
+    let g:purescript_disable_indent = 1
 <
 
 

--- a/indent/purescript.vim
+++ b/indent/purescript.vim
@@ -5,11 +5,9 @@
 " author: raichoo (raichoo@googlemail.com)
 "
 
-if exists('b:did_indent')
+if exists('g:purescript_disable_indent')
   finish
 endif
-
-let b:did_indent = 0
 
 if !exists('g:purescript_indent_case')
   " case xs of


### PR DESCRIPTION
Adds a new setting (`g:purescript_disable_indent`) to disable the indentation altogether.

Fixes #66 

**Checklist:**

- [x] Briefly described the change
- [x] Opened an issue before investing a significant amount of work into changes
- [x] Updated README.md with any new configuration options and behavior
- [x] Updated CHANGELOG.md with the proposed changes
- [x] Ran `generate-doc.sh` to re-generate the documentation
