### PR TITLE
Syntax: Highlight TODO/FIXME/XXX in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes (😱!!!):
 New features:
   - add vim manual (`:help purescript-vim`) [p73][]
   - add setting to disable indentation (`let g:purescript_disable_indent = 1`) [p75][]
+  - highlight TODO/FIXME/XXX in comments [p76][]
 
 Bugfixes:
   - docs did not reflect the code in using the `g:` prefix for indentation configuration [p73][]
@@ -62,3 +63,4 @@ class RowLacking (entry :: Type)
 [p68][https://github.com/purescript-contrib/purescript-vim/pull/70]
 [p73][https://github.com/purescript-contrib/purescript-vim/pull/73]
 [p75][https://github.com/purescript-contrib/purescript-vim/pull/75]
+[p76][https://github.com/purescript-contrib/purescript-vim/pull/76]

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -156,10 +156,11 @@ syn region purescriptString start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
 syn region purescriptMultilineString start=+"""+ end=+"""+ fold contains=@Spell
 
 " Comment
-syn match purescriptLineComment "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$" contains=@Spell
+syn match purescriptLineComment "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$" contains=purescriptCommentTodo,@Spell
 syn region purescriptBlockComment start="{-" end="-}" fold
   \ contains=purescriptBlockComment,@Spell
 syn cluster purescriptComment contains=purescriptLineComment,purescriptBlockComment,@Spell
+syn keyword purescriptCommentTodo contained TODO FIXME XXX
 
 syn sync minlines=50
 


### PR DESCRIPTION
Highlight the following keywords in single line comments

* TODO
* FIXME
* XXX

This might be helpful during development. It's also common in other languages: <https://github.com/vim/vim/search?q=todo>

![image](https://user-images.githubusercontent.com/13085980/102696791-3f6ef880-4231-11eb-8dd8-6cd0f67e8a57.png)


**Checklist:**

- [x] Briefly described the change
- [ ] Opened an issue before investing a significant amount of work into changes
- [ ] Updated README.md with any new configuration options and behavior
- [x] Updated CHANGELOG.md with the proposed changes
- [ ] Ran `generate-doc.sh` to re-generate the documentation
