### PR TITLE
docs(readme): add instruction for vim 8 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Bugfixes:
 
 Other improvements:
   - rename default branch to 'main', clarify readme, add changelog [p73][]
+  - add install instruction for vim 8 packages
 
 ## [v1.0.0](https://github.com/purescript-contrib/purescript-vim/releases/tag/v1.0.0) - 2017-10-19
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ filetype on
 filetype plugin indent on
 ```
 
+### Vim 8 packages
+
+If you have vim version 8 (`vim --version | head -n1`), you can install plugins with the native pack system:
+
+```sh
+mkdir -p ~/.vim/pack/plugins/start/
+cd ~/.vim/pack/plugins/start/
+git clone https://github.com/purescript-contrib/purescript-vim.git
+```
+
 ### Pathogen
 
 If you are using [Pathogen][], clone this repo into your `~/.vim/bundle` directory and you are ready to go.

--- a/doc/purescript-vim.txt
+++ b/doc/purescript-vim.txt
@@ -3,6 +3,7 @@
 |purescript-intro|    purescript-vim
 |purescript-Installation|    Installation
 |purescript-Manual-Installation-no-plugin-manager|    Manual Installation (no plugin manager)
+|purescript-Vim-8-packages|    Vim 8 packages
 |purescript-Pathogen|    Pathogen
 |purescript-vim-plug|    vim-plug
 |purescript-Configuration|    Configuration
@@ -38,6 +39,17 @@ Be sure that the following lines are in your `.vimrc`
     syntax on
     filetype on
     filetype plugin indent on
+<
+
+
+VIM 8 PACKAGES                *purescript-Vim-8-packages*
+
+If you have vim version 8 (`vim --version | head -n1`), you can install plugins with the native pack system:
+
+>
+    mkdir -p ~/.vim/pack/plugins/start/
+    cd ~/.vim/pack/plugins/start/
+    git clone https://github.com/purescript-contrib/purescript-vim.git
 <
 
 


### PR DESCRIPTION
I followed [this guide](https://medium.com/@paulodiovani/installing-vim-8-plugins-with-the-native-pack-system-39b71c351fea) to install this repo as a vim 8 plugin.

**Checklist:**

- [x] Briefly described the change
- [ ] Opened an issue before investing a significant amount of work into changes
- [x] Updated README.md with any new configuration options and behavior
- [x] Updated CHANGELOG.md with the proposed changes
- [x] Ran `generate-doc.sh` to re-generate the documentation
