### PR TITLE
Syntax: Fold imports

### DIFF
--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -87,6 +87,7 @@ syn match purescriptImportHiding "hiding"
   \ contains=purescriptHidingKeyword
   \ nextgroup=purescriptImportParams
   \ skipwhite
+syn region purescriptFoldImports start="import" end=/import.*\n^$/ fold transparent keepend
 
 " Function declaration
 syn region purescriptFunctionDecl


### PR DESCRIPTION
**Checklist:**

- [X] Briefly described the change  
When opening PureScript files one is bombarded with import statements. Typcally 1/3rd of PureScript code are import statements. Therefore it is favorable to be able to fold them away. In my vim init file I also have the following entry to support folding for PureScript when opening a file:
```
augroup purescript_fold
     autocmd!
     autocmd Filetype purescript setlocal foldmethod=syntax
augroup end
```
- [X] Opened an issue before investing a significant amount of work into changes  
NA
- [X] Updated README.md with any new configuration options and behavior  
NA
- [X] Updated CHANGELOG.md with the proposed changes  
NA
- [X] Ran `generate-doc.sh` to re-generate the documentation
