### PR TITLE
Some Unicode char were not accounted for in indent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ New features:
 
 Bugfixes:
   - docs did not reflect the code in using the `g:` prefix for indentation configuration [p73][]
+  - some Unicode characters were not accounted for for the indentation [p84][]
   - highlight all bicameral scripts, not just Latin ones [p85][]
 
 Other improvements:

--- a/indent/purescript.vim
+++ b/indent/purescript.vim
@@ -50,7 +50,7 @@ if !exists('g:purescript_indent_dot')
 endif
 
 setlocal indentexpr=GetPurescriptIndent()
-setlocal indentkeys=!^F,o,O,},=where,=in,=::,=->,=→,==>,=⇒
+setlocal indentkeys=!^F,o,O,},=where,=in,=::,=∷,=->,=→,==>,=⇒
 
 function! s:GetSynStack(lnum, col)
   return map(synstack(a:lnum, a:col), { key, val -> synIDattr(val, "name") })
@@ -88,7 +88,7 @@ function! GetPurescriptIndent()
     return s
   endif
 
-  if prevline =~ '^\S.*::' && line !~ '^\s*\(\.\|->\|→\|=>\|⇒\)' && prevline !~ '^instance'
+  if prevline =~ '^\S.*\(::\|∷\)' && line !~ '^\s*\(\.\|->\|→\|=>\|⇒\)' && prevline !~ '^instance'
     " f :: String
     "	-> String
     return 0
@@ -107,14 +107,14 @@ function! GetPurescriptIndent()
     endif
   endif
 
-  let s = match(line, '\%(\\.\{-}\)\@<=->')
+  let s = match(line, '\%(\\.\{-}\)\@<=\(->\|→\)')
   if s >= 0
     " inline lambda
     return indent(v:lnum)
   endif
 
   " indent rules for -> (lambdas and case expressions)
-  let s = match(line, '->')
+  let s = match(line, '\(->\|→\)')
   let p = match(prevline, '\\')
   " protect that we are not in a type signature
   " and not in a case expression
@@ -136,7 +136,7 @@ function! GetPurescriptIndent()
     return match(prevline, '\S') + &l:shiftwidth
   endif
 
-  if prevline =~ '^\s*\(::\|∷\)\s*forall'
+  if prevline =~ '^\s*\(::\|∷\)\s*\(forall\|∀\)'
     return match(prevline, '\S') + g:purescript_indent_dot
   endif
 


### PR DESCRIPTION
Only some of the Unicode characters worked some of the time. This helps fix some of those indentation issue. I'm not a VimL RegExp expert, so I'll be testing this branch locally for a while.

**Checklist:**

- [x] Briefly described the change
- [ ] Opened an issue before investing a significant amount of work into changes
- [ ] Updated README.md with any new configuration options and behavior
- [x] Updated CHANGELOG.md with the proposed changes
- [ ] Ran `generate-doc.sh` to re-generate the documentation
