### PR TITLE
Support bicameral scripts beyond Latin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ New features:
 
 Bugfixes:
   - docs did not reflect the code in using the `g:` prefix for indentation configuration [p73][]
+  - highlight all bicameral scripts, not just Latin ones [p85][]
 
 Other improvements:
   - rename default branch to 'main', clarify readme, add changelog [p73][]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes (😱!!!):
-  - use "-- %s" instead of "{--%s--}" for comemnts [p68][]
+  - use `-- %s` instead of `{--%s--}` for comments [p68][]
 
 New features:
-  - add vim manual (`:help purescript-vim`) [p73][]
+  - add Vim manual (`:help purescript-vim`) [p73][]
   - add setting to disable indentation (`let g:purescript_disable_indent = 1`) [p75][]
   - highlight TODO/FIXME/XXX in comments [p76][]
 
@@ -17,8 +17,8 @@ Bugfixes:
   - highlight all bicameral scripts, not just Latin ones [p85][]
 
 Other improvements:
-  - rename default branch to 'main', clarify readme, add changelog [p73][]
-  - add install instruction for vim 8 packages
+  - rename default branch to `main`, clarify readme, add changelog [p73][]
+  - add install instruction for Vim 8 packages
 
 ## [v1.0.0](https://github.com/purescript-contrib/purescript-vim/releases/tag/v1.0.0) - 2017-10-19
 

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -10,7 +10,7 @@ if exists("b:current_syntax")
 endif
 
 " Values
-syn match purescriptIdentifier "\<[_a-z]\(\w\|\'\)*\>"
+syn match purescriptIdentifier "\<[_[:lower:]]\(\w\|\'\)*\>"
 syn match purescriptNumber "0[xX][0-9a-fA-F]\+\|0[oO][0-7]\|[0-9]\+"
 syn match purescriptFloat "[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\="
 syn keyword purescriptBoolean true false
@@ -22,23 +22,23 @@ syn match purescriptDelimiter "[,;|.()[\]{}]"
 syn match purescriptType "\%(\<class\s\+\)\@15<!\<\u\w*\>" contained
   \ containedin=purescriptTypeAlias
   \ nextgroup=purescriptType,purescriptTypeVar skipwhite
-syn match purescriptTypeVar "\<[_a-z]\(\w\|\'\)*\>" contained
+syn match purescriptTypeVar "\<[_[:lower:]]\(\w\|\'\)*\>" contained
   \ containedin=purescriptData,purescriptNewtype,purescriptTypeAlias,purescriptFunctionDecl
-syn region purescriptTypeExport matchgroup=purescriptType start="\<[A-Z]\(\S\&[^,.]\)*\>("rs=e-1 matchgroup=purescriptDelimiter end=")" contained extend
+syn region purescriptTypeExport matchgroup=purescriptType start="\<[[:upper:]]\(\S\&[^,.]\)*\>("rs=e-1 matchgroup=purescriptDelimiter end=")" contained extend
   \ contains=purescriptConstructor,purescriptDelimiter
 
 " Constructor
 syn match purescriptConstructor "\%(\<class\s\+\)\@15<!\<\u\w*\>"
-syn region purescriptConstructorDecl matchgroup=purescriptConstructor start="\<[A-Z]\w*\>" end="\(|\|$\)"me=e-1,re=e-1 contained
+syn region purescriptConstructorDecl matchgroup=purescriptConstructor start="\<[[:upper:]]\w*\>" end="\(|\|$\)"me=e-1,re=e-1 contained
   \ containedin=purescriptData,purescriptNewtype
   \ contains=purescriptType,purescriptTypeVar,purescriptDelimiter,purescriptOperatorType,purescriptOperatorTypeSig,@purescriptComment
 
 
 " Function
-syn match purescriptFunction "\%(\<instance\s\+\|\<class\s\+\)\@18<!\<[_a-z]\(\w\|\'\)*\>" contained
-" syn match purescriptFunction "\<[_a-z]\(\w\|\'\)*\>" contained
+syn match purescriptFunction "\%(\<instance\s\+\|\<class\s\+\)\@18<!\<[_[:lower:]]\(\w\|\'\)*\>" contained
+" syn match purescriptFunction "\<[_[:lower:]]\(\w\|\'\)*\>" contained
 syn match purescriptFunction "(\%(\<class\s\+\)\@18<!\(\W\&[^(),\"]\)\+)" contained extend
-syn match purescriptBacktick "`[_A-Za-z][A-Za-z0-9_\.]*`"
+syn match purescriptBacktick "`[_[:upper:][:lower:]][[:upper:][:lower:]0-9_\.]*`"
 
 " Class
 syn region purescriptClassDecl start="^\%(\s*\)class\>"ms=e-5 end="\<where\>\|$"
@@ -48,7 +48,7 @@ syn region purescriptClassDecl start="^\%(\s*\)class\>"ms=e-5 end="\<where\>\|$"
 syn match purescriptClass "\<class\>" containedin=purescriptClassDecl contained
   \ nextgroup=purescriptClassName
   \ skipnl
-syn match purescriptClassName "\<[A-Z]\w*\>" containedin=purescriptClassDecl contained
+syn match purescriptClassName "\<[[:upper:]]\w*\>" containedin=purescriptClassDecl contained
 
 " Module
 syn match purescriptModuleName "\(\u\w\*\.\?\)*" contained excludenl
@@ -90,18 +90,18 @@ syn match purescriptImportHiding "hiding"
 
 " Function declaration
 syn region purescriptFunctionDecl
-  \ excludenl start="^\z(\s*\)\(\(foreign\s\+import\)\_s\+\)\?[_a-z]\(\w\|\'\)*\_s\{-}\(::\|∷\)"
+  \ excludenl start="^\z(\s*\)\(\(foreign\s\+import\)\_s\+\)\?[_[:lower:]]\(\w\|\'\)*\_s\{-}\(::\|∷\)"
   \ end="^\z1\=\S"me=s-1,re=s-1 keepend
   \ contains=purescriptFunctionDeclStart,purescriptForall,purescriptOperatorType,purescriptOperatorTypeSig,purescriptType,purescriptTypeVar,purescriptDelimiter,@purescriptComment
 syn region purescriptFunctionDecl
-  \ excludenl start="^\z(\s*\)where\z(\s\+\)[_a-z]\(\w\|\'\)*\_s\{-}\(::\|∷\)"
+  \ excludenl start="^\z(\s*\)where\z(\s\+\)[_[:lower:]]\(\w\|\'\)*\_s\{-}\(::\|∷\)"
   \ end="^\(\z1\s\{5}\z2\)\=\S"me=s-1,re=s-1 keepend
   \ contains=purescriptFunctionDeclStart,purescriptForall,purescriptOperatorType,purescriptOperatorTypeSig,purescriptType,purescriptTypeVar,purescriptDelimiter,@purescriptComment
 syn region purescriptFunctionDecl
-  \ excludenl start="^\z(\s*\)let\z(\s\+\)[_a-z]\(\w\|\'\)*\_s\{-}\(::\|∷\)"
+  \ excludenl start="^\z(\s*\)let\z(\s\+\)[_[:lower:]]\(\w\|\'\)*\_s\{-}\(::\|∷\)"
   \ end="^\(\z1\s\{3}\z2\)\=\S"me=s-1,re=s-1 keepend
   \ contains=purescriptFunctionDeclStart,purescriptForall,purescriptOperatorType,purescriptOperatorTypeSig,purescriptType,purescriptTypeVar,purescriptDelimiter,@purescriptComment
-syn match purescriptFunctionDeclStart "^\s*\(\(foreign\s\+import\|let\|where\)\_s\+\)\?\([_a-z]\(\w\|\'\)*\)\_s\{-}\(::\|∷\)" contained
+syn match purescriptFunctionDeclStart "^\s*\(\(foreign\s\+import\|let\|where\)\_s\+\)\?\([_[:lower:]]\(\w\|\'\)*\)\_s\{-}\(::\|∷\)" contained
   \ contains=purescriptImportKeyword,purescriptWhere,purescriptLet,purescriptFunction,purescriptOperatorType
 syn keyword purescriptForall forall
 syn match purescriptForall "∀"
@@ -132,21 +132,21 @@ syn match purescriptOperatorTypeSig "\(->\|<-\|=>\|<=\|::\|[∷∀→←⇒⇐]\
   \ nextgroup=purescriptType skipwhite skipnl skipempty
 
 " Type definition
-syn region purescriptData start="^data\s\+\([A-Z]\w*\)" end="^\S"me=s-1,re=s-1 transparent
-syn match purescriptDataStart "^data\s\+\([A-Z]\w*\)" contained
+syn region purescriptData start="^data\s\+\([[:upper:]]\w*\)" end="^\S"me=s-1,re=s-1 transparent
+syn match purescriptDataStart "^data\s\+\([[:upper:]]\w*\)" contained
   \ containedin=purescriptData
   \ contains=purescriptStructure,purescriptType,purescriptTypeVar
 syn match purescriptForeignData "\<foreign\s\+import\s\+data\>"
   \ contains=purescriptImportKeyword,purescriptStructure
   \ nextgroup=purescriptType skipwhite
 
-syn region purescriptNewtype start="^newtype\s\+\([A-Z]\w*\)" end="^\S"me=s-1,re=s-1 transparent
-syn match purescriptNewtypeStart "^newtype\s\+\([A-Z]\w*\)" contained
+syn region purescriptNewtype start="^newtype\s\+\([[:upper:]]\w*\)" end="^\S"me=s-1,re=s-1 transparent
+syn match purescriptNewtypeStart "^newtype\s\+\([[:upper:]]\w*\)" contained
   \ containedin=purescriptNewtype
   \ contains=purescriptStructure,purescriptType,purescriptTypeVar
 
-syn region purescriptTypeAlias start="^type\s\+\([A-Z]\w*\)" end="^\S"me=s-1,re=s-1 transparent
-syn match purescriptTypeAliasStart "^type\s\+\([A-Z]\w*\)" contained
+syn region purescriptTypeAlias start="^type\s\+\([[:upper:]]\w*\)" end="^\S"me=s-1,re=s-1 transparent
+syn match purescriptTypeAliasStart "^type\s\+\([[:upper:]]\w*\)" contained
   \ containedin=purescriptTypeAlias
   \ contains=purescriptStructure,purescriptType,purescriptTypeVar
 


### PR DESCRIPTION
PureScript does support these, so the syntax highlighter should as well.
Curiously, `[[:alpha:]]` does not, but `[[:upper:][:lower:]]` does (at
least on my machine).

**Checklist:**

- [x] Briefly described the change
- [x] Opened an issue before investing a significant amount of work into changes
- [x] Updated README.md with any new configuration options and behavior
- [x] Updated CHANGELOG.md with the proposed changes
- [x] Ran `generate-doc.sh` to re-generate the documentation
