### PR TITLE
Conceal with Unicode (disabled by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ New features:
   - add setting to disable indentation (`let g:purescript_disable_indent = 1`) [p75][]
   - highlight TODO/FIXME/XXX in comments [p76][]
   - additional TODO highlighting in comments [p81][]
+  - add Unicode symbol conceal (`let g:purescript_unicode_conceal_enable = 1`) [p87][]
 
 Bugfixes:
   - docs did not reflect the code in using the `g:` prefix for indentation configuration [p73][]

--- a/README.md
+++ b/README.md
@@ -128,6 +128,78 @@ let g:purescript_indent_dot = 1
 	  -> Maybe (List a, a)
 ```
 
+## Unicode conceal
+
+If you wish to have some symbols concealed for their unicode equivalents, you may use these options. Each setting will conceal the following ASCII code block for an example output.
+
+```purescript
+sum :: forall a f. Foldable f => Semiring a => f a -> a
+sum = foldl (\a b -> a + b) zero
+
+sumMod2 :: forall f. Foldable f => f Int -> Int
+sumMod2 xs = mod (sum xs) 2
+
+isSumEven :: forall f. Foldable => f Int -> Boolean
+isSumEven = (==) 0 <<< sumMod2
+```
+
+### g:purescript_unicode_conceal_enable
+
+```vim
+let g:purescript_unicode_conceal_enable = 1
+```
+
+Enables concealing. Conceals as:
+
+```purescript
+sum ∷ ∀ a f. Foldable f ⇒ Semiring a ⇒ f a → a
+sum = foldl (λa b → a + b) zero
+
+sumMod2 ∷ ∀ f. Foldable f ⇒ f Int → Int
+sumMod2 xs = mod (sum xs) 2
+
+isSumEven ∷ ∀ f. Foldable ⇒ f Int → Boolean
+isSumEven = (≡) 0 ∘ sumMod2
+```
+
+### g:purescript_unicode_conceal_disable_common
+
+```vim
+let g:purescript_unicode_conceal_disable_common = 1
+```
+
+Disables concealing common symbols and just uses ones the compiler supports. Concealed as:
+
+```purescript
+sum ∷ ∀ a f. Foldable f ⇒ Semiring a ⇒ f a → a
+sum = foldl (\a b → a + b) zero
+
+sumMod2 ∷ ∀ f. Foldable f ⇒ f Int → Int
+sumMod2 xs = mod (sum xs) 2
+
+isSumEven ∷ ∀ f. Foldable ⇒ f Int → Boolean
+isSumEven = (==) 0 <<< sumMod2
+```
+
+### g:purescript_unicode_conceal_enable_discretionary
+
+```vim
+let g:purescript_unicode_conceal_enable_discretionary = 1
+```
+
+Enables discretionary symbols concealing less common symbols that deviate further from the written code. Concealed as:
+
+```purescript
+∑ ∷ ∀ a f. Foldable f ⇒ Semiring a ⇒ f a → a
+∑ = foldl (λa b → a + b) ∅
+
+sumMod2 ∷ ∀ f. Foldable f ⇒ f ℤ → ℤ
+sumMod2 xs = mod (∑ xs) 2
+
+isSumEven ∷ ∀ f. Foldable ⇒ f ℤ → 𝔹
+isSumEven = (≡) 0 ∘ sumMod2
+```
+
 ## Contributing
 
 Contributing checklist:

--- a/after/syntax/purescript.vim
+++ b/after/syntax/purescript.vim
@@ -1,0 +1,71 @@
+" Great for those that want Unicode, but their project’s config or style guide
+" does not endorse the usage. Much of the code is based on VimL code for
+" concealing Haskell, Idris, and OCaml.
+if !get(g:, "purescript_unicode_conceal_enable", 1) || !has("conceal") || &enc != "utf-8"
+	finish
+endif
+
+" vim: set fenc=utf-8:
+syntax match purescriptNiceOperator "->" conceal cchar=→
+	\ containedin=purescriptTypeExport,purescriptConstructorDecl,purescriptClassDecl,purescriptFunctionDecl,purescriptData,purescriptNewtype,purescriptTypeAlias,purescriptOperatorType
+syntax match purescriptNiceOperator "<-" conceal cchar=←
+	\ containedin=purescriptTypeExport,purescriptConstructorDecl,purescriptClassDecl,purescriptFunctionDecl,purescriptData,purescriptNewtype,purescriptTypeAlias,purescriptOperatorType
+syntax match purescriptNiceOperator "=>" conceal cchar=⇒
+	\ containedin=purescriptTypeExport,purescriptConstructorDecl,purescriptClassDecl,purescriptFunctionDecl,purescriptData,purescriptNewtype,purescriptTypeAlias,purescriptOperatorType
+syntax match purescriptNiceOperator "<=\ze[^<]" conceal cchar=⇐
+	\ containedin=purescriptTypeExport,purescriptConstructorDecl,purescriptClassDecl,purescriptFunctionDecl,purescriptData,purescriptNewtype,purescriptTypeAlias,purescriptOperatorType
+syntax match purescriptNiceOperator "::" conceal cchar=∷
+	\ containedin=purescriptTypeExport,purescriptConstructorDecl,purescriptClassDecl,purescriptFunctionDecl,purescriptData,purescriptNewtype,purescriptTypeAlias,purescriptOperatorType
+syntax keyword purescriptNiceOperator forall conceal cchar=∀
+	\ containedin=purescriptTypeExport,purescriptConstructorDecl,purescriptClassDecl,purescriptFunctionDecl,purescriptData,purescriptNewtype,purescriptTypeAlias,purescriptOperatorType
+syntax keyword purescriptNiceOperator exists conceal cchar=∃
+	\ containedin=purescriptTypeExport,purescriptConstructorDecl,purescriptClassDecl,purescriptFunctionDecl,purescriptData,purescriptNewtype,purescriptTypeAlias,purescriptOperatorType
+
+if !get(g:, "purescript_unicode_conceal_disable_common", 0)
+	syntax match purescriptNiceOperator "\\\ze[[:alpha:][:space:]_([]" conceal cchar=λ
+	syntax match purescriptNiceOperator "\~>" conceal cchar=↝
+	syntax match purescriptNiceOperator "<<<" conceal cchar=∘
+	syntax match purescriptNiceOperator "==" conceal cchar=≡
+	syntax match purescriptNiceOperator "/=" conceal cchar=≠
+	" deals with Kliesli operator false positives
+	syntax match purescriptNiceOperator "<=\ze[^<]" conceal cchar=≤
+	syntax match purescriptNiceOperator ">=\ze[^>]" conceal cchar=≥
+endif
+
+" These have a general meaning in mathematics; nothing in this block should be
+" for ‘fun’ or ‘cute’. Perhaps that’s more suited for a new block or extension…
+if get(g:, "purescript_unicode_conceal_enable_discretionary", 0)
+	syntax match purescriptNiceOperator "\<sum\>" conceal cchar=∑
+	syntax match purescriptNiceOperator "\<product\>" conceal cchar=∏
+	syntax match purescriptNiceOperator "\<sqrt\>" conceal cchar=√
+	syntax match purescriptNiceOperator "\<not\>" conceal cchar=¬
+	syntax match purescriptNiceOperator "||\ze[[:alpha:][:space:]_([]" conceal cchar=∨
+	syntax match purescriptNiceOperator "&&\ze[[:alpha:][:space:]_([]" conceal cchar=∧
+	syntax match purescriptNiceOperator "`elem`" conceal cchar=∈
+	syntax match purescriptNiceOperator "`notElem`" conceal cchar=∉
+	syntax match purescriptNiceOperator "`union`" conceal cchar=∪
+	syntax match purescriptNiceOperator "`intersect`" conceal cchar=∩
+	syntax match purescriptNiceOperator "\<infinity\>" conceal cchar=∞
+	syntax match purescriptNiceIdentifier "\<pi\>" conceal cchar=π
+	syntax match purescriptNiceIdentifier "\<tau\>" conceal cchar=τ
+	syntax match purescriptNiceIdentifier "\<empty\>" conceal cchar=∅
+	syntax match purescriptNiceIdentifier "\<zero\>" conceal cchar=∅
+	syntax match purescriptNiceType "\<Boolean\>" conceal cchar=𝔹
+		\ containedin=purescriptType
+	syntax match purescriptNiceType "\<Int\>"  conceal cchar=ℤ
+		\ containedin=purescriptType
+	syntax match purescriptNiceType "\<Natural\>"  conceal cchar=ℕ
+		\ containedin=purescriptType
+	syntax match purescriptNiceType "\<Void\>"  conceal cchar=⊥
+		\ containedin=purescriptType
+	" TODO: conceal primes with ′, ″, ‴, ⁗
+endif
+
+highlight link purescriptNiceIdentifier Identifier
+highlight! link Conceal Identifier
+highlight link purescriptNiceType Type
+highlight! link Conceal Type
+highlight link  purescriptNiceOperator Operator
+highlight! link Conceal Operator
+
+setlocal conceallevel=2

--- a/doc/purescript-vim.txt
+++ b/doc/purescript-vim.txt
@@ -15,6 +15,10 @@
 |purescript-g-purescript_indent_where|    g:purescript_indent_where
 |purescript-g-purescript_indent_do|    g:purescript_indent_do
 |purescript-g-purescript_indent_dot|    g:purescript_indent_dot
+|purescript-Unicode-conceal|    Unicode conceal
+|purescript-g-purescript_unicode_conceal_enable|    g:purescript_unicode_conceal_enable
+|purescript-g-purescript_unicode_conceal_disable_common|    g:purescript_unicode_conceal_disable_common
+|purescript-g-purescript_unicode_conceal_enable_discretionary|    g:purescript_unicode_conceal_enable_discretionary
 |purescript-Contributing|    Contributing
 
 PURESCRIPT-VIM                *purescript-intro*
@@ -161,6 +165,82 @@ G:PURESCRIPT_INDENT_DOT                *purescript-g-purescript_indent_dot*
           :: forall a
           >. List a
           -> Maybe (List a, a)
+<
+
+
+UNICODE CONCEAL                *purescript-Unicode-conceal*
+
+If you wish to have some symbols concealed for their unicode equivalents, you may use these options. Each setting will conceal the following ASCII code block for an example output.
+
+>
+    sum :: forall a f. Foldable f => Semiring a => f a -> a
+    sum = foldl (\a b -> a + b) zero
+
+    sumMod2 :: forall f. Foldable f => f Int -> Int
+    sumMod2 xs = mod (sum xs) 2
+
+    isSumEven :: forall f. Foldable => f Int -> Boolean
+    isSumEven = (==) 0 <<< sumMod2
+<
+
+
+G:PURESCRIPT_UNICODE_CONCEAL_ENABLE                *purescript-g-purescript_unicode_conceal_enable*
+
+>
+    let g:purescript_unicode_conceal_enable = 1
+<
+
+Enables concealing. Conceals as:
+
+>
+    sum ∷ ∀ a f. Foldable f ⇒ Semiring a ⇒ f a → a
+    sum = foldl (λa b → a + b) zero
+
+    sumMod2 ∷ ∀ f. Foldable f ⇒ f Int → Int
+    sumMod2 xs = mod (sum xs) 2
+
+    isSumEven ∷ ∀ f. Foldable ⇒ f Int → Boolean
+    isSumEven = (≡) 0 ∘ sumMod2
+<
+
+
+G:PURESCRIPT_UNICODE_CONCEAL_DISABLE_COMMON                *purescript-g-purescript_unicode_conceal_disable_common*
+
+>
+    let g:purescript_unicode_conceal_disable_common = 1
+<
+
+Disables concealing common symbols and just uses ones the compiler supports. Concealed as:
+
+>
+    sum ∷ ∀ a f. Foldable f ⇒ Semiring a ⇒ f a → a
+    sum = foldl (\a b → a + b) zero
+
+    sumMod2 ∷ ∀ f. Foldable f ⇒ f Int → Int
+    sumMod2 xs = mod (sum xs) 2
+
+    isSumEven ∷ ∀ f. Foldable ⇒ f Int → Boolean
+    isSumEven = (==) 0 <<< sumMod2
+<
+
+
+G:PURESCRIPT_UNICODE_CONCEAL_ENABLE_DISCRETIONARY                *purescript-g-purescript_unicode_conceal_enable_discretionary*
+
+>
+    let g:purescript_unicode_conceal_enable_discretionary = 1
+<
+
+Enables discretionary symbols concealing less common symbols that deviate further from the written code. Concealed as:
+
+>
+    ∑ ∷ ∀ a f. Foldable f ⇒ Semiring a ⇒ f a → a
+    ∑ = foldl (λa b → a + b) ∅
+
+    sumMod2 ∷ ∀ f. Foldable f ⇒ f ℤ → ℤ
+    sumMod2 xs = mod (∑ xs) 2
+
+    isSumEven ∷ ∀ f. Foldable ⇒ f ℤ → 𝔹
+    isSumEven = (≡) 0 ∘ sumMod2
 <
 
 


### PR DESCRIPTION
Borrowing from the VimL files for concealing in the Haskell, Idris, and OCaml spheres, this is a reasonable set of concealed characters users can opt into. There are additional flags to disable all characters not directly supported by the compiler as well as allowing discretionary characters that look more similar to a math paper. With it being disabled by default, current users shouldn’t be affected.

Motivation: while I use Unicode in my personal projects and have a custom Prelude inspired by a former employer, I do have to work with the broader community and contract with teams that don’t use these symbols. While the utility of conceal isn’t high, the aesthetics and joy it can bring may make the environment just a little bit cozier.

**Checklist:**

- [x] Briefly described the change
- [ ] Opened an issue before investing a significant amount of work into changes
- [x] Updated README.md with any new configuration options and behavior
- [x] Updated CHANGELOG.md with the proposed changes
- [x] Ran `generate-doc.sh` to re-generate the documentation
